### PR TITLE
Fix arbitrary upload bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ If recognized, a JSON object will be returned of the form:
 
 Examples:
 
+Synchronous check on if a filename includes an acceptable extension:
+```javascript
+const assetTypes = require('scratch-asset-types');
+const result = assetTypes.acceptableExtension('filename');
+```
+
 Synchronous check on a buffer:
 ```javascript
 const assetTypes = require('scratch-asset-types');

--- a/index.js
+++ b/index.js
@@ -3,6 +3,19 @@
 const typesList = require('./lib/typeslist');
 const readChunk = require('read-chunk');
 
+// Check if the file extension provided is in our
+// list of acceptable file formats.
+// acceptable, return true
+// not acceptable, return false
+module.exports.acceptableExtension = fileName => {
+    const pieces = fileName.split('.');
+    if (pieces && pieces.length > 1 && pieces[pieces.length - 1] in typesList) {
+        return true;
+    }
+
+    return false;
+};
+
 module.exports.bufferCheck = input => {
     const buf = (input instanceof Uint8Array) ? input : new Uint8Array(input);
 
@@ -23,6 +36,11 @@ module.exports.bufferCheck = input => {
 
         return true;
     };
+
+    // Starts with a <, assume SVG
+    if (check([0x3c])) {
+        return typesList.svg;
+    }
 
     if (check([0xFF, 0xD8, 0xFF])) {
         return typesList.jpg;

--- a/lib/typeslist.js
+++ b/lib/typeslist.js
@@ -7,6 +7,7 @@ module.exports = {
     json: {ext: 'json', mime: 'application/json'},
     mj2: {ext: 'jpg', mime: 'image/jpg'},
     png: {ext: 'png', mime: 'image/png'},
+    svg: {ext: 'svg', mime: 'image/svg+xml'},
     webp: {ext: 'webp', mime: 'image/webp'},
     wav: {ext: 'wav', mime: 'audio/x-wav'},
     zip: {ext: 'zip', mime: 'application/zip'}

--- a/test/unit/filetype.js
+++ b/test/unit/filetype.js
@@ -3,7 +3,7 @@ const fileType = require('../../index');
 const typesList = require('../../lib/typeslist');
 
 const checkList = [
-    'gif', 'jpg', 'json', 'png', 'wav', 'webp', 'zip'];
+    'gif', 'jpg', 'json', 'png', 'svg', 'wav', 'webp', 'zip'];
 
 tap.test('check-types', t => {
     checkList.forEach(thisType => {
@@ -23,3 +23,21 @@ checkList.forEach(thisType => fileType.asyncCheck(`./test/fixtures/test.${thisTy
         t.equals(result.mime, typesList[thisType].mime);
         t.end();
     })));
+
+tap.test('Accept recognized extensions', t => {
+    checkList.forEach(thisType => {
+        const name = `test.${thisType}`;
+        t.ok(fileType.acceptableExtension(name));
+    });
+    t.end();
+});
+
+tap.test('reject unrecognized extension', t => {
+    t.notOk(fileType.acceptableExtension('test.exe'));
+    t.notOk(fileType.acceptableExtension('test.app'));
+    t.notOk(fileType.acceptableExtension('test.framework'));
+    t.notOk(fileType.acceptableExtension('test.doc'));
+    t.notOk(fileType.acceptableExtension('test.txt'));
+    t.notOk(fileType.acceptableExtension('test.dll'));
+    t.end();
+});


### PR DESCRIPTION
### Resolves

- Resolves LLK/scratch-assets/issues/513

### Proposed Changes

This adds the SVG type to the accepted types list along with its mime type.
It also adds a check on the extension name of the file name.

### Reason for Changes

By narrowing down which extensions are valid for uploads, it first keeps file names that, when downloaded, look like an executable or runnable program to an OS.
It also provides some detection of SVGs that is still naive but provides more restrictions on uploaded content in cases where the SVG is being uploaded with the correct mime type vs `octet-stream`

### Test Coverage

Unit tests added to ensure the checks respond as expected.